### PR TITLE
Attempt to retry installing winflexbison

### DIFF
--- a/appveyor/appveyor.yml
+++ b/appveyor/appveyor.yml
@@ -1,6 +1,6 @@
 #  appveyor.yml
 install:
-  - cinst winflexbison
+  - appveyor-retry cinst winflexbison
   - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64'
 
 before_build:


### PR DESCRIPTION
Installing it can fail, but the build shouldn't immediately on that account.