### PR TITLE
Install docbook-xml to have DTD locally

### DIFF
--- a/travis/.travis.yml
+++ b/travis/.travis.yml
@@ -13,6 +13,7 @@ addons:
       - libldap2-dev
       - libicu-dev
       - docbook
+      - docbook-xml
       - docbook-dsssl
       - docbook-xsl
       - libxml2-utils


### PR DESCRIPTION
When running xmllint to validate the docs tree, the dtd will be
source locally before trying to load as external entity.  Since
the oasis-open.org entity was moved to redirect to HTTPS this
no longer works as xmllint only supports http. Fix by installing
the DTD locally via the docbook-xml package (as per the postgres
documentation).

Below is the errormessage incurred:

/usr/bin/xmllint --path . --noout --valid postgres.sgml

error : Unknown IO error
postgres.sgml:21: warning: failed to load external entity "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd"