### PR TITLE
New Linux-alignment-sanitizers task

### DIFF
--- a/cirrus/.cirrus.yml
+++ b/cirrus/.cirrus.yml
@@ -89,6 +89,33 @@ task:
   test_script:
     - su postgres -c 'make -s check-world' || su postgres -c '( for F in ` find . -name initdb.log -o -name regression.diffs ` ; do echo === $F === ; head -1000 $F ; done ; exit 1 )'
 
+# ====== Linux-alignment-sanitizers ======
+# The same as above, but compile code with alignment sanitizers.  This task
+# helps to detect pointer misalignment even without access to a strict alignment
+# machine.  We make it a separate task to explicitly know if the code fails
+# just on alignment or not only on that.  It seems sufficient to run tests with
+# alignment sanitizers just on one OS because pointer misalignment is unlikely
+# to be OS-specific.
+
+task:
+  name: Linux-alignment-sanitizers
+  container:
+    image: debian:latest
+  install_script:
+    - uname -a
+    - apt-get --yes update
+    - DEBIAN_FRONTEND=noninteractive apt-get --yes install gcc libreadline-dev flex bison make perl libipc-run-perl clang llvm-dev libperl-dev libpython-dev tcl-dev libldap2-dev libicu-dev docbook-xml docbook-xsl fop libxml2-utils xsltproc krb5-admin-server krb5-kdc krb5-user slapd ldap-utils libssl-dev pkg-config locales-all liblz4-dev
+  create_user_script:
+    - useradd -m postgres
+    - chown -R postgres:postgres .
+  build_script:
+    - su postgres -c 'CC="-O2 -fsanitize=alignment -fno-sanitize-recover=alignment" ./configure --enable-cassert --enable-debug --enable-tap-tests --with-tcl --with-python --with-perl --with-ldap --with-openssl --with-icu --with-llvm'
+    - su postgres -c 'make -s -j4'
+  docs_script:
+    - su postgres -c 'make docs'
+  test_script:
+    - su postgres -c 'make -s check-world' || su postgres -c '( for F in ` find . -name initdb.log -o -name regression.diffs ` ; do echo === $F === ; head -1000 $F ; done ; exit 1 )'
+
 # ====== Windows ======
 # This doesn't work.  I think it's the wrong version of Visual Studio and/or
 # msbuild, but I don't understand Windows.  Help!


### PR DESCRIPTION
The new task runs tests on the code compiled with alignment sanitizers.  That
helps to detect helps to detect pointer misalignment even without access to
a strict alignment machine.