### PR TITLE
Use a custom docker images for cirrus tests on Linux

### DIFF
--- a/cirrus/.cirrus.yml
+++ b/cirrus/.cirrus.yml
@@ -73,13 +73,8 @@ task:
 task:
   name: Linux
   container:
-    image: debian:latest
-  install_script:
-    - uname -a
-    - apt-get --yes update
-    - DEBIAN_FRONTEND=noninteractive apt-get --yes install gcc libreadline-dev flex bison make perl libipc-run-perl clang llvm-dev libperl-dev libpython-dev tcl-dev libldap2-dev libicu-dev docbook-xml docbook-xsl fop libxml2-utils xsltproc krb5-admin-server krb5-kdc krb5-user slapd ldap-utils libssl-dev pkg-config locales-all liblz4-dev
-  create_user_script:
-    - useradd -m postgres
+    image: pgcfbot/cfbot-cirrus-debian:latest
+  set_permissions_script:
     - chown -R postgres:postgres .
   build_script:
     - su postgres -c './configure --enable-cassert --enable-debug --enable-tap-tests --with-tcl --with-python --with-perl --with-ldap --with-openssl --with-icu --with-llvm'

--- a/docker/README
+++ b/docker/README
@@ -1,0 +1,2 @@
+This directory contains Dockerfile specifications for creating the custom images
+used by the cfbot testing.

--- a/docker/cirrus/debian/Dockerfile
+++ b/docker/cirrus/debian/Dockerfile
@@ -1,0 +1,3 @@
+FROM debian:latest
+RUN apt-get --yes update && DEBIAN_FRONTEND=noninteractive apt-get --yes install gcc libreadline-dev flex bison make perl libipc-run-perl clang llvm-dev libperl-dev libpython-dev tcl-dev libldap2-dev libicu-dev docbook-xml docbook-xsl fop libxml2-utils xsltproc krb5-admin-server krb5-kdc krb5-user slapd ldap-utils libssl-dev pkg-config locales-all liblz4-dev
+RUN useradd -m postgres


### PR DESCRIPTION
Instead of running the installs every time (which takes several minuts),
pre-cook a docker image with the details we need and use that one in the
tests.

@macdice make sure I have set you up with permissions to push at that dockerhub url before merging :)