### PR TITLE
Don't squash patches into one big commit

### DIFF
--- a/cfbot_config.py.example
+++ b/cfbot_config.py.example
@@ -6,6 +6,8 @@ import sys
 GITHUB_USER=None
 GITHUB_REPO="postgres"
 
+GITHUB_FULL_REPO=f"{GITHUB_USER}/{GITHUB_REPO}"
+
 # which CI providers are enabled
 CI_MODULES = ("cirrus",)
 

--- a/cfbot_patch.py
+++ b/cfbot_patch.py
@@ -117,8 +117,8 @@ def update_patchbase_tree(repo_dir):
 def get_commit_id(repo_dir):
   return subprocess.check_output("cd %s && git show | head -1 | cut -d' ' -f2" % repo_dir, shell=True).decode('utf-8').strip()
 
-def make_branch(burner_repo_path, commitfest_id, submission_id):
-  branch = "commitfest/%s/%s" % (commitfest_id, submission_id)
+def make_branch(burner_repo_path, submission_id):
+  branch = f"cf/{submission_id}"
   logging.info("creating branch %s" % branch)
   # blow away the branch if it exists already
   subprocess.call("""cd %s && git branch -q -D %s > /dev/null 2> /dev/null""" % (burner_repo_path, branch), shell=True) # ignore failure
@@ -210,7 +210,7 @@ def process_submission(conn, commitfest_id, submission_id):
     with open(dest, "wb+") as f:
       f.write(cfbot_util.slow_fetch_binary(patch_url))
   # we applied the patch; now make it into a branch with a commit on it
-  branch = make_branch(burner_repo_path, commitfest_id, submission_id)
+  branch = make_branch(burner_repo_path, submission_id)
   # apply the patches inside the jail
   output, rcode = patchburner_ctl("apply", want_rcode=True)
   # write the patch output to a public log file

--- a/cfbot_patchburner_chroot_ctl.sh
+++ b/cfbot_patchburner_chroot_ctl.sh
@@ -73,10 +73,10 @@ create_patchburner()
       for bin in sh dash ; do
         cp /bin/$bin $CHROOT_DIR//bin/
       done
-      for bin in patch unzip gzip gunzip tar find sort ; do
+      for bin in cat patch unzip git gzip gunzip sed tar find sort ; do
         cp /usr/bin/$bin $CHROOT_DIR/usr/bin/
       done
-      for lib in libbz2.so libacl.so libselinux.so libc.so libm.so libattr.so libpcre.so libpcre2-8.so libdl.so libpthread.so ; do
+      for lib in libbz2.so libacl.so libselinux.so libc.so libm.so libattr.so libpcre.so libpcre2-8.so libdl.so libpthread.so libz.so; do
         cp /lib/x86_64-linux-gnu/$lib* $CHROOT_DIR/lib/x86_64-linux-gnu/
       done
       cp /lib64/ld-linux-x86-64.so* $CHROOT_DIR/lib64/
@@ -87,9 +87,15 @@ create_patchburner()
       ;;
   esac
 
+  # "git sendmail" uses /dev/null internally, so we need to have a /dev
+  # directory. We clean the file up afterwards, so it's not a big deal that
+  # it's not actually a special device
+  mkdir $CHROOT_DIR/dev
+  touch $CHROOT_DIR/dev/null
+
   # create the patching script
   mkdir $CHROOT_DIR/work/patches
-  cat > $CHROOT_DIR/work/apply-patches.sh <<EOF
+  cat > $CHROOT_DIR/work/apply-patches.sh <<'EOF'
 #!/bin/sh
 #
 # apply all patches found in /work/patches
@@ -98,25 +104,47 @@ set -e
 
 # unpack and zip archives, tarballs etc
 cd /work/patches
-for f in \$(find . -name '*.tgz' -o -name '*.tar.gz' -o -name '*.tar.bz2') ; do
-  echo "=== expanding \$f"
-  tar xzvf \$f
+for f in $(find . -name '*.tgz' -o -name '*.tar.gz' -o -name '*.tar.bz2') ; do
+  echo "=== expanding $f"
+  tar xzvf $f
 done
-for f in \$(find . -name '*.gz') ; do
-  echo "=== expanding \$f"
-  gunzip \$f
+for f in $(find . -name '*.gz') ; do
+  echo "=== expanding $f"
+  gunzip $f
 done
-for f in \$(find . -name '*.zip') ; do
-  echo "=== expanding \$f"
-  unzip \$f
+for f in $(find . -name '*.zip') ; do
+  echo "=== expanding $f"
+  unzip $f
 done
 
 # now apply all .patch and .diff files
 cd /work/postgresql
-for f in \$(cd /work/patches && find . -name '*.patch' -o -name '*.diff' | sort) ; do
-  echo "=== applying patch \$f"
-  patch --no-backup-if-mismatch -p1 -V none -f < "/work/patches/\$f"
+
+# But first set up the git user
+git config user.name "Commitfest Bot"
+git config user.email "cfbot@cputube.org"
+
+for f in $(cd /work/patches && find . -name '*.patch' -o -name '*.diff' | sort) ; do
+  echo "=== applying patch $f"
+  git mailinfo ../msg ../patch < "/work/patches/$f" > ../info
+  # Clean out /dev/null in case git mailinfo wrote something to it
+  : > /dev/null
+
+  NAME=$(sed -n -e 's/^Author: //p' ../info)
+  EMAIL=$(sed -n -e 's/^Email: //p' ../info)
+  SUBJECT=$(sed -n -e 's/^Subject: //p' ../info)
+  DATE=$(sed -n -e 's/^Date: //p' ../info)
+  MESSAGE="$(cat ../msg)"
+  MESSAGE="${SUBJECT:-"[PATCH]: $f"}${MESSAGE:+
+
+}${MESSAGE}"
+
+  patch --no-backup-if-mismatch -p1 -V none -f < "/work/patches/$f"
+  git add .
+  git commit -m "$MESSAGE" --author="${NAME:-Commitfest Bot} <${EMAIL:-cfbot@cputube.org}>" --date="${DATE:-now}" --allow-empty
+
 done
+
 EOF
   chmod 775 $CHROOT_DIR/work/apply-patches.sh
   chown -R $RUNAS_USER:$RUNAS_USER $CHROOT_DIR/work

--- a/cfbot_web.py
+++ b/cfbot_web.py
@@ -355,9 +355,9 @@ def build_page(conn, commit_id, commitfest_id, submissions, filter_author, activ
           patch_html += """&nbsp;<a title="Interesting log excerpts found: %s" href="/highlights/all.html#%s">\u26a0</a>""" % (", ".join(submission.has_highlights), submission.id)
       if submission.last_branch_message_id:
         patch_html += """&nbsp;<a title="Patch email" href="https://www.postgresql.org/message-id/%s">\u2709</a>""" % submission.last_branch_message_id
-      branch = f"commitfest/{submission.commitfest_id}/{submission.id}"
-      patch_html += f"""&nbsp;<a title="Diff on GitHub" href="https://github.com/{cfbot_config.GITHUB_USER}/{cfbot_config.GITHUB_REPO}/compare/{branch}~1...{branch}">D</a>"""
-      patch_html += """&nbsp;<a title="Test history" href="https://cirrus-ci.com/github/postgresql-cfbot/postgresql/commitfest/%s/%s">H</a>""" % (submission.commitfest_id, submission.id)
+      branch = f"cf/{submission.id}"
+      patch_html += f"""&nbsp;<a title="Diff on GitHub" href="https://github.com/{cfbot_config.GITHUB_FULL_REPO}/compare/{branch}~1...{branch}">D</a>"""
+      patch_html += f"""&nbsp;<a title="Test history" href="https://cirrus-ci.com/github/{cfbot_config.GITHUB_FULL_REPO}/{branch}">H</a>"""
 
       # write out an entry
       f.write("""

--- a/cfbot_web.py
+++ b/cfbot_web.py
@@ -355,8 +355,9 @@ def build_page(conn, commit_id, commitfest_id, submissions, filter_author, activ
           patch_html += """&nbsp;<a title="Interesting log excerpts found: %s" href="/highlights/all.html#%s">\u26a0</a>""" % (", ".join(submission.has_highlights), submission.id)
       if submission.last_branch_message_id:
         patch_html += """&nbsp;<a title="Patch email" href="https://www.postgresql.org/message-id/%s">\u2709</a>""" % submission.last_branch_message_id
+      branch = f"commitfest/{submission.commitfest_id}/{submission.id}"
+      patch_html += f"""&nbsp;<a title="Diff on GitHub" href="https://github.com/{cfbot_config.GITHUB_USER}/{cfbot_config.GITHUB_REPO}/compare/{branch}~1...{branch}">D</a>"""
       patch_html += """&nbsp;<a title="Test history" href="https://cirrus-ci.com/github/postgresql-cfbot/postgresql/commitfest/%s/%s">H</a>""" % (submission.commitfest_id, submission.id)
-
 
       # write out an entry
       f.write("""


### PR DESCRIPTION
As I explained in https://github.com/macdice/cfbot/pull/17 the cfbot repo is the easiest way for me to take a
quick look at postgres patches in a decent diff interface, as well as
having an easy way of checking them out locally. Instead of squashing
the patches together it's much nicer if they are committed separately.

The suggested changes `git mailinfo` to extract to extract commit info
in case the patch was created by `git format-patch`. It explicitely
doesn't use `git am` to apply the patch, because that chokes on many
more merge conflicts as regular `patch`/`gpatch` does.

It also adds a link on the cfbot webpage to the github branch where you can see the commits. An example of such a link is here:
https://github.com/JelteF/postgres/compare/commitfest/48/4766~1...commitfest/48/4766