### PR TITLE
Avoid possible division by zero

### DIFF
--- a/cfbot_web.py
+++ b/cfbot_web.py
@@ -329,7 +329,7 @@ def build_page(conn, commit_id, commitfest_id, submissions, filter_author, activ
             expected_runtime = expected_runtimes[build_result.task_name]
           else:
             expected_runtime = 60 * 30
-          if build_result.age > 0:
+          if build_result.age > 0 and expected_runtime > 0:
             fraction = build_result.age / expected_runtime
           else:
             fraction = 0.1


### PR DESCRIPTION
I ran into this division by zero, I guess the hocus pocus time
prediction returning something strange for me. That should probably be
fixed, but being defensive here to always allow the page to build seems
like a good idea too (and easier to do for me than understanding the
hocus pocus time prediction).
