### PR TITLE
Use CFApp /api/v1/commitfest/active endpoint to find CFIds

### DIFF
--- a/cfbot_commitfest_rpc.py
+++ b/cfbot_commitfest_rpc.py
@@ -6,6 +6,7 @@
 import cfbot_config
 import cfbot_util
 import html
+import json
 
 # from html.parser import HTMLParser
 import re
@@ -188,6 +189,25 @@ def get_current_commitfest_id():
     if result is None:
         raise Exception("Could not determine the current Commitfest ID")
     return result
+
+
+def get_commitfest_workflow():
+    result = cfbot_util.slow_fetch(
+        cfbot_config.COMMITFEST_HOST + "/api/v1/commitfest/active"
+    )
+    jsonobj = json.loads(result)
+    workflow = jsonobj["workflow"]
+
+    if not workflow["open"]:
+        workflow["open"]["id"] = None
+
+    if not workflow["inprogress"]:
+        workflow["inprogress"]["id"] = None
+
+    if not workflow["parked"]:
+        workflow["parked"]["id"] = None
+
+    return workflow
 
 
 if __name__ == "__main__":

--- a/cfbot_web.py
+++ b/cfbot_web.py
@@ -240,8 +240,7 @@ WITH task_positions AS (SELECT DISTINCT ON (task_name)
     return results
 
 
-def rebuild(conn, commitfest_id):
-    submissions = load_submissions(conn, commitfest_id)
+def rebuild(conn, commitfest_id, commitfest_name, submissions):
     build_page(
         conn,
         "x",
@@ -249,17 +248,12 @@ def rebuild(conn, commitfest_id):
         submissions,
         None,
         None,
-        os.path.join(cfbot_config.WEB_ROOT, "index.html"),
+        os.path.join(cfbot_config.WEB_ROOT, commitfest_name, ".html"),
     )
-    build_page(
-        conn,
-        "x",
-        commitfest_id + 1,
-        submissions,
-        None,
-        None,
-        os.path.join(cfbot_config.WEB_ROOT, "next.html"),
-    )
+    return submissions
+
+
+def rebuild_authors(conn, submissions):
     for author in unique_authors(submissions):
         build_page(
             conn,
@@ -333,8 +327,9 @@ def build_page(
   <body>
     <h1>PostgreSQL Patch Tester</h1>
     <p>
-      <a href="index.html">Current commitfest</a> |
-      <a href="next.html">Next commitfest</a> |
+      <a href="inprogress.html">In Progress commitfest</a> |
+      <a href="open.html">Open commitfest</a> |
+      <a href="draft.html">Draft commitfest</a> |
       <a href="https://wiki.postgresql.org/wiki/Cfbot">FAQ</a> |
       <a href="statistics.html">Statistics</a> |
       <a href="highlights/all.html">Highlights</a>


### PR DESCRIPTION
This will need to be applied after the corresponding CFApp commit that exposes the API.

This is only lightly tested.  I wanted to get something out since I've pushed a PR for the CFApp side of this.

I did quite a bit more API-based work but have yet to get a running instance using the scraping against a dev CFApp in place.  Assuming the replaced code worked switching from the "+1" computation of a CF to getting three explicit CF IDs from the API should not impact any later code in the processing stream.

I made an educated guess on the rebuild/build_page code.  Putting out links to potentially non-existent URLs (the In Progress one will not be active for like half the year) isn't ideal but given the user base and non-primary nature of this UI the expedient solution seems reasonable.
